### PR TITLE
// swift-tools-version:5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ swift package init --type executable
 Create `Package.swift`:
 
 ```swift
+// swift-tools-version:5.1
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
This is added to avoid “is using Swift tools version 3.1.0 which is no
longer supported; consider using '// swift-tools-version:5.1' to
specify the current tools version”