### PR TITLE
Change the absolute path to an easy-to-use relative path

### DIFF
--- a/Examples/hello-bot/Package.resolved
+++ b/Examples/hello-bot/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "TelegramBotSDK",
-        "repositoryURL": "/Users/cipi1965/Projects/telegram-bot-swift",
+        "repositoryURL": "/Users/hd/work/telegram-bot-swift",
         "state": {
           "branch": null,
-          "revision": "141be1529345e23c13d57c0ae7aaf0dbc038b815",
-          "version": "1.2.2"
+          "revision": "9f8cfea4dcce1d984c76e0a6732e3d836cd30671",
+          "version": "1.2.7"
         }
       }
     ]

--- a/Examples/shopster-bot/Package.resolved
+++ b/Examples/shopster-bot/Package.resolved
@@ -12,7 +12,7 @@
       },
       {
         "package": "TelegramBotSDK",
-        "repositoryURL": "/Users/cipi1965/Projects/telegram-bot-swift",
+        "repositoryURL": "../../../telegram-bot-swift",
         "state": {
           "branch": null,
           "revision": "4d6e94eb1fcbbe1cbe5f931adc0971b9ebf8449a",

--- a/Examples/word-reverse-bot/Package.resolved
+++ b/Examples/word-reverse-bot/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "TelegramBotSDK",
-        "repositoryURL": "/Users/cipi1965/Projects/telegram-bot-swift",
+        "repositoryURL": "../../../telegram-bot-swift",
         "state": {
           "branch": null,
           "revision": "141be1529345e23c13d57c0ae7aaf0dbc038b815",


### PR DESCRIPTION
If this is not changed, swift build will not work properly.