### PR TITLE
Fix scanUpToString returning nil on Linux

### DIFF
--- a/Sources/TelegramBotSDK/Extensions/Scanner+Compatibility.swift
+++ b/Sources/TelegramBotSDK/Extensions/Scanner+Compatibility.swift
@@ -81,6 +81,9 @@ extension Scanner {
 
     #if os(Linux) || os(Windows)
     func scanUpTo(_ string: String) -> String? {
+        if string.isEmpty {
+            return scanUpToCharacters(from: CharacterSet())
+        }
         return scanUpToString(string)
     }
     #elseif os(OSX)


### PR DESCRIPTION
Behavior of scanUpToString differs from scanUpToString(into:).
The former returns nil when argument is "", the latter returns rest of the string.